### PR TITLE
Changed health endpoint response schema.

### DIFF
--- a/src/main/java/com/uci/orchestrator/Health/HealthController.java
+++ b/src/main/java/com/uci/orchestrator/Health/HealthController.java
@@ -1,5 +1,6 @@
 package com.uci.orchestrator.Health;
 
+import com.fasterxml.jackson.databind.JsonNode;
 import com.uci.dao.service.HealthService;
 import com.uci.utils.model.ApiResponse;
 import com.uci.utils.model.ApiResponseParams;
@@ -7,6 +8,7 @@ import lombok.extern.slf4j.Slf4j;
 import reactor.core.publisher.Mono;
 
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.actuate.health.Status;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -25,9 +27,17 @@ public class HealthController {
 		return healthService.getAllHealthNode().map(health -> ApiResponse.builder()
 				.id("api.health")
 				.params(ApiResponseParams.builder().build())
-				.responseCode(HttpStatus.OK.name())
 				.result(health)
 				.build()
-		).map(ResponseEntity::ok);
+		).map(response -> {
+			if (((JsonNode)response.result).get("status").textValue().equals(Status.UP.getCode())) {
+				response.responseCode = HttpStatus.OK.name();
+				return new ResponseEntity<>(response, HttpStatus.OK);
+			}
+			else {
+				response.responseCode = HttpStatus.SERVICE_UNAVAILABLE.name();
+				return new ResponseEntity<>(response, HttpStatus.SERVICE_UNAVAILABLE);
+			}
+		});
     }
 }

--- a/src/main/java/com/uci/orchestrator/Health/ServiceStatusController.java
+++ b/src/main/java/com/uci/orchestrator/Health/ServiceStatusController.java
@@ -1,25 +1,17 @@
 package com.uci.orchestrator.Health;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.JsonMappingException;
 import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.uci.dao.service.HealthService;
 import com.uci.utils.model.ApiResponse;
 import com.uci.utils.model.ApiResponseParams;
-import com.uci.utils.telemetry.LogTelemetryBuilder;
-import com.uci.utils.telemetry.TelemetryLogger;
 
 import lombok.extern.slf4j.Slf4j;
 
-import java.io.IOException;
-
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
 import reactor.core.publisher.Mono;
 
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.actuate.health.Status;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -35,23 +27,28 @@ public class ServiceStatusController {
 	private HealthService healthService;
 
     /**
-     * In use by sunbird team - to check service liveliness & readliness
-     * @return
-     * @throws JsonProcessingException
-     */
+	 * In use by sunbird team - to check service liveliness & readliness
+	 *
+	 * @return
+	 * @throws JsonProcessingException
+	 */
     @RequestMapping(value = "/health", method = RequestMethod.GET, produces = { "application/json", "text/json" })
-    public ResponseEntity<ApiResponse> statusCheck() throws JsonProcessingException {
-        ObjectMapper mapper = new ObjectMapper();
-        JsonNode resultNode = mapper.readTree("{\"healthy\":true}");
-
-        ApiResponse response = ApiResponse.builder()
-                .id("api.service.health.cassandra")
-                .params(ApiResponseParams.builder().build())
-                .responseCode(HttpStatus.OK.name())
-                .result(resultNode)
-                .build();
-
-        return ResponseEntity.ok(response);
+    public Mono<ResponseEntity<ApiResponse>> statusCheck() throws JsonProcessingException {
+		return healthService.getAllHealthNode().map(health -> ApiResponse.builder()
+				.id("api.health")
+				.params(ApiResponseParams.builder().build())
+				.result(health)
+				.build()
+		).map(response -> {
+			if (((JsonNode)response.result).get("status").textValue().equals(Status.UP.getCode())) {
+				response.responseCode = HttpStatus.OK.name();
+				return new ResponseEntity<>(response, HttpStatus.OK);
+			}
+			else {
+				response.responseCode = HttpStatus.SERVICE_UNAVAILABLE.name();
+				return new ResponseEntity<>(response, HttpStatus.SERVICE_UNAVAILABLE);
+			}
+		});
     }
 
     @RequestMapping(value = "/health/cassandra", method = RequestMethod.GET, produces = { "application/json", "text/json" })
@@ -60,10 +57,18 @@ public class ServiceStatusController {
 				ApiResponse.builder()
 				.id("api.service.health.cassandra")
 				.params(ApiResponseParams.builder().build())
-				.responseCode(HttpStatus.OK.name())
 				.result(result)
 				.build())
-				.map(ResponseEntity::ok);
+				.map(response -> {
+					if (((JsonNode)response.result).get("status").textValue().equals(Status.UP.getCode())) {
+						response.responseCode = HttpStatus.OK.name();
+						return new ResponseEntity<>(response, HttpStatus.OK);
+					}
+					else {
+						response.responseCode = HttpStatus.SERVICE_UNAVAILABLE.name();
+						return new ResponseEntity<>(response, HttpStatus.SERVICE_UNAVAILABLE);
+					}
+				});
     }
 
     @RequestMapping(value = "/health/kafka", method = RequestMethod.GET, produces = { "application/json", "text/json" })
@@ -72,10 +77,18 @@ public class ServiceStatusController {
 				ApiResponse.builder()
 				.id("api.service.health.kafka")
 				.params(ApiResponseParams.builder().build())
-				.responseCode(HttpStatus.OK.name())
 				.result(result)
 				.build())
-				.map(ResponseEntity::ok);
+				.map(response -> {
+					if (((JsonNode)response.result).get("status").textValue().equals(Status.UP.getCode())) {
+						response.responseCode = HttpStatus.OK.name();
+						return new ResponseEntity<>(response, HttpStatus.OK);
+					}
+					else {
+						response.responseCode = HttpStatus.SERVICE_UNAVAILABLE.name();
+						return new ResponseEntity<>(response, HttpStatus.SERVICE_UNAVAILABLE);
+					}
+				});
     }
 
     @RequestMapping(value = "/health/campaign", method = RequestMethod.GET, produces = { "application/json", "text/json" })
@@ -83,9 +96,17 @@ public class ServiceStatusController {
 		return healthService.getCampaignUrlHealthNode().map(result ->
 				ApiResponse.builder().id("api.service.health.campaign")
 				.params(ApiResponseParams.builder().build())
-				.responseCode(HttpStatus.OK.name())
 				.result(result)
 				.build())
-				.map(ResponseEntity::ok);
+				.map(response -> {
+					if (((JsonNode)response.result).get("status").textValue().equals(Status.UP.getCode())) {
+						response.responseCode = HttpStatus.OK.name();
+						return new ResponseEntity<>(response, HttpStatus.OK);
+					}
+					else {
+						response.responseCode = HttpStatus.SERVICE_UNAVAILABLE.name();
+						return new ResponseEntity<>(response, HttpStatus.SERVICE_UNAVAILABLE);
+					}
+				});
     }
 }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -6,10 +6,7 @@ spring.kafka.consumer.auto-offset-reset=earliest
 spring.kafka.bootstrap-servers=${BOOTSTRAP_SERVERS}
 spring.kafka.properties.schema.registry.url=${REGISTRY_URL}
 campaign=${KAFKA_CAMPAIGN_TOPIC}
-inboundUnprocessed=${KAFKA_INBOUND_UNPROCESSED_TOPIC}
 inboundProcessed=${KAFKA_INBOUND_PROCESSED_TOPIC}
-gupshup-opted-out=${KAFKA_INBOUND_GS_OPTED_OUT_TOPIC}
-inbound-error=${KAFKA_INBOUND_ERROR_TOPIC}
 odk-transformer=${KAFKA_ODK_TRANSFORMER_TOPIC}
 kafka.logs.topic = logs
 broadcast-transformer=${KAFKA_BROADCAST_TRANSFORMER_TOPIC:#{"broadcast-transformer"}}
@@ -25,7 +22,7 @@ outbound=${KAFKA_OUTBOUND_TOPIC}
 cassandra.contactpoints=${CASSANDRA_URL}
 cassandra.port=${CASSANDRA_PORT}
 keyspace-name=${CASSANDRA_KEYSPACE}
-// Count of cassandra migrations run till now
+# Count of cassandra migrations run till now
 cassandra.migration.count=${CASSANDRA_MIGRATION_COUNT}
 
 spring.data.cassandra.local-datacenter=datacenter1


### PR DESCRIPTION
Fixes: #4 #31 

Example response:

```
{
    "id": "api.health",
    "ver": "3.0",
    "ts": "2023-04-14T13:42:19Z",
    "params": {
        "resmsgid": "aca4112c-7808-4218-9b35-98eb91f74cc2",
        "msgid": null,
        "status": "success",
        "err": null,
        "errmsg": null
    },
    "responseCode": "SERVICE_UNAVAILABLE",
    "result": {
        "details": {
            "cassandra": {
                "status": "UP"
            },
            "kafka": {
                "status": "UP"
            },
            "campaign": {
                "status": "DOWN",
                "message": "404 Not Found from GET http://143.110.255.220:9999/admin/v1/health"
            }
        },
        "status": "DOWN"
    }
}
```